### PR TITLE
Fixed group matching error

### DIFF
--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.models import Group
-from django.core.mail import send_mail
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -13,7 +12,10 @@ def user_saved(sender, instance, created, **kwargs):
     # Actions for newly created User
     if created:
         # Add new user to Customer group
-        group = Group.objects.get(name='customer')
+        try:
+            group = Group.objects.get(name='customer')
+        except Group.DoesNotExist:
+            group = Group.objects.create(name='customer')
         instance.groups.add(group)
         print("User Created!")
 

--- a/price_comparison_gp1/settings.py
+++ b/price_comparison_gp1/settings.py
@@ -33,8 +33,8 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     # Price Comparison apps
-    'accounts',
-    'comments',
+    'accounts.apps.AccountsConfig',
+    'comments.apps.CommentsConfig',
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -139,7 +139,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'static/images')
 # SMTP Configuration for sending emails
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = ''
-EMAIL_PORT = ""
+EMAIL_PORT = 0
 EMAIL_USE_SSL = True
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''


### PR DESCRIPTION
The previous version expected a customer group to already exist. The code has been fixed in "accounts/signals.py" to catch the "DoesNotExist" error and create the customer group.